### PR TITLE
Fix uninstall button layout and restore SVG naming

### DIFF
--- a/gtk-3.0/titlebuttons-alt/button-restore-backdrop-active.svg
+++ b/gtk-3.0/titlebuttons-alt/button-restore-backdrop-active.svg
@@ -4,7 +4,7 @@
    height="16"
    version="1.1"
    id="svg15"
-   sodipodi:docname="button-resotre-backdrop-active.svg"
+   sodipodi:docname="button-restore-backdrop-active.svg"
    inkscape:version="1.3.2 (091e20ef0f, 2023-11-25)"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"

--- a/gtk-3.0/titlebuttons-alt/button-restore-backdrop-active@2.svg
+++ b/gtk-3.0/titlebuttons-alt/button-restore-backdrop-active@2.svg
@@ -4,7 +4,7 @@
    height="16"
    version="1.1"
    id="svg15"
-   sodipodi:docname="button-resotre-backdrop-active.svg"
+   sodipodi:docname="button-restore-backdrop-active.svg"
    inkscape:version="1.3.2 (091e20ef0f, 2023-11-25)"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"

--- a/gtk-4.0/titlebuttons-alt/button-restore-backdrop-active.svg
+++ b/gtk-4.0/titlebuttons-alt/button-restore-backdrop-active.svg
@@ -4,7 +4,7 @@
    height="16"
    version="1.1"
    id="svg15"
-   sodipodi:docname="button-resotre-backdrop-active.svg"
+   sodipodi:docname="button-restore-backdrop-active.svg"
    inkscape:version="1.3.2 (091e20ef0f, 2023-11-25)"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"

--- a/gtk-4.0/titlebuttons-alt/button-restore-backdrop-active@2.svg
+++ b/gtk-4.0/titlebuttons-alt/button-restore-backdrop-active@2.svg
@@ -4,7 +4,7 @@
    height="16"
    version="1.1"
    id="svg15"
-   sodipodi:docname="button-resotre-backdrop-active.svg"
+   sodipodi:docname="button-restore-backdrop-active.svg"
    inkscape:version="1.3.2 (091e20ef0f, 2023-11-25)"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -15,6 +15,6 @@ for dir in gtk-3.0 gtk-4.0; do
 done
 
 # Reset window controls to default
-gsettings set org.gnome.desktop.wm.preferences button-layout 'close:maximize'
+gsettings reset org.gnome.desktop.wm.preferences button-layout
 
 echo "Uninstallation complete. Please log out and log back in to apply changes."


### PR DESCRIPTION
## Summary
- reset GNOME button layout on uninstall instead of setting an incorrect configuration
- fix misnamed restore button icons for alternate themes

## Testing
- `bash -n install.sh uninstall.sh`


------
https://chatgpt.com/codex/tasks/task_e_68909d235b04832eb66e8304a8976621