### PR TITLE
Handle backups safely in install script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,8 +1,15 @@
 #!/bin/bash
 
+# Ensure the configuration directory exists
+mkdir -p "$HOME/.config"
+
 # Backup GTK config folders if they exist
 for dir in gtk-3.0 gtk-4.0; do
     if [ -d "$HOME/.config/$dir" ]; then
+        # Remove any previous backup to avoid mv failures
+        if [ -e "$HOME/.config/$dir.bak" ]; then
+            rm -rf "$HOME/.config/$dir.bak"
+        fi
         mv "$HOME/.config/$dir" "$HOME/.config/$dir.bak"
         echo "Backed up $HOME/.config/$dir to $HOME/.config/$dir.bak"
     fi


### PR DESCRIPTION
## Summary
- ensure the config directory exists before copying
- remove existing backups before backing up old configs

## Testing
- `shellcheck install.sh uninstall.sh`
- `bash -n install.sh uninstall.sh`
- `HOME=/tmp/testhome GSETTINGS_BACKEND=memory ./install.sh` (run twice)
- `HOME=/tmp/testhome GSETTINGS_BACKEND=memory ./uninstall.sh`


------
https://chatgpt.com/codex/tasks/task_e_6890b7772330832eafd219bbbff39df2